### PR TITLE
Fix incorrect server host in generated html

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
 # Unofficial Pixiv API doc
 
-![.github/workflows/ci.yml](https://github.com/hanshsieh/pixiv-api-doc/workflows/.github/workflows/ci.yml/badge.svg)  
+[![CI](https://github.com/hanshsieh/pixiv-api-doc/workflows/CI/badge.svg?event=push)](https://github.com/hanshsieh/pixiv-api-doc/actions?query=workflow%3ACI)
 [Document](https://hanshsieh.github.io/pixiv-api-doc/)  

--- a/api.yaml
+++ b/api.yaml
@@ -11,8 +11,6 @@ info:
     name: MIT License
     url: https://opensource.org/licenses/MIT
   version: 1.0.0
-servers:
-  - url: https://app-api.pixiv.net
 paths:
   /auth/token:
     post:


### PR DESCRIPTION
For the tool we use for generating the html, it's incorrectly generating
the server host when the server url is overwritten in an API. Try to
bypass the problem.